### PR TITLE
fix bu \n doesn't work on windows, use good CRLF instead of

### DIFF
--- a/cordonbleu-service/src/test/java/com/benromberg/cordonbleu/service/email/EmailTemplateTest.java
+++ b/cordonbleu-service/src/test/java/com/benromberg/cordonbleu/service/email/EmailTemplateTest.java
@@ -18,8 +18,9 @@ public class EmailTemplateTest {
                 return super.getPlainBodyTemplate().add("value", SEPARATOR_BETWEEN_HEADER_AND_FOOTER);
             }
         };
-        assertThat(template.getPlainBody()).contains("\n\n" + SEPARATOR_BETWEEN_HEADER_AND_FOOTER + "\n\n");
-        assertThat(template.getPlainBody()).doesNotContain("\n\n\n");
+        String CRLF = System.getProperty("line.separator"); // \n doesn't work on windows, so find the good CRLF for platform
+        assertThat(template.getPlainBody()).contains(CRLF + CRLF + SEPARATOR_BETWEEN_HEADER_AND_FOOTER + CRLF + CRLF);
+        assertThat(template.getPlainBody()).doesNotContain(CRLF + CRLF + CRLF);
     }
 
     @Test


### PR DESCRIPTION
Hi,

I propose a bug fixes :  on windows, you have to use \r\n instead of \n only.

`System.getProperty("line.separator");` allow to manage it with the host machine

Regards,

Nicolas